### PR TITLE
Reduce the amount of data being logged by moving a majority to DEBUG

### DIFF
--- a/tracking/people/srl_nearest_neighbor_tracker/src/srl_nearest_neighbor_tracker/ros/ros_interface.cpp
+++ b/tracking/people/srl_nearest_neighbor_tracker/src/srl_nearest_neighbor_tracker/ros/ros_interface.cpp
@@ -157,17 +157,16 @@ void ROSInterface::publishTracks(ros::Time currentRosTime, const Tracks& tracks)
         if(!m_geometryUtils.posePassesSanityCheck(trackedPerson.pose, true))
         {
             // Output track state history to console, best viewed using rqt Logger Console plugin
-            if(ROSCONSOLE_MIN_SEVERITY <= ROSCONSOLE_SEVERITY_WARN) {
+            ROS_WARN_STREAM("Pose of TrackedPerson " << trackedPerson.track_id << " first tracked " << trackedPerson.age.toSec()
+                            << " sec ago does not pass sanity check, will not publish this track");
+            if(ROSCONSOLE_MIN_SEVERITY <= ROSCONSOLE_SEVERITY_DEBUG) {
                 stringstream ss; size_t historyIndex  = track->stateHistory.size();                
                 foreach(FilterState::Ptr historicState, track->stateHistory) {
                     ss << "\n\n=== Historic motion filter state #" << --historyIndex << ": ===\n\n" << historicState << "\n";
                 }
-
-                ROS_WARN_STREAM("Pose of TrackedPerson " << trackedPerson.track_id << " first tracked " << trackedPerson.age.toSec()
-                                << " sec ago does not pass sanity check, will not publish this track:\n\n"
-                                << trackedPerson
-                                << "\n\n-----------------\n\n"
-                                << "Offending track's motion filter state history:" << ss.str());
+                ROS_DEBUG_STREAM(trackedPerson << " does not pass sanity check:"
+                                 << "\n\n-----------------\n\n"
+                                 << "Offending track's motion filter state history:" << ss.str());
             }
 
             // Skip publishing this track.


### PR DESCRIPTION
We were seeing syslogs with sizes pushing 100GBs because of the history
was being dumped multiple times per second and each history was 100+ lines
long!

To balance data with verbosity the same data will still be logged but
only if this code is built in "Debug" mode (see the CMakeLists.txt file
for what that means).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/spencer_people_tracking/3)
<!-- Reviewable:end -->
